### PR TITLE
🧹 Remove leftover console.logs in client/coach-photo API

### DIFF
--- a/app/api/client/coach-photo/route.ts
+++ b/app/api/client/coach-photo/route.ts
@@ -42,7 +42,6 @@ export async function GET() {
     });
 
     if (!assignment?.coach) {
-      console.log("[ClientCoachPhoto] no active coach assignment userId=%s", user.id);
       return NextResponse.json({ photoUrl: null, coachName: null });
     }
 
@@ -50,11 +49,6 @@ export async function GET() {
     const storagePath = coach.profilePhotoPath ?? null;
 
     if (!storagePath) {
-      console.log(
-        "[ClientCoachPhoto] coach has no photo coachId=%s userId=%s",
-        coach.id,
-        user.id
-      );
       return NextResponse.json({
         photoUrl: null,
         coachName: [coach.firstName, coach.lastName].filter(Boolean).join(" ") || null,
@@ -80,7 +74,6 @@ export async function GET() {
       });
     }
 
-    console.log("[ClientCoachPhoto] source=supabase coachId=%s userId=%s", coach.id, user.id);
     return NextResponse.json(
       {
         photoUrl: data.signedUrl,


### PR DESCRIPTION
🎯 **What:** Removed leftover `console.log` statements used for debugging in `app/api/client/coach-photo/route.ts`. Left `console.error` intact.
💡 **Why:** To improve code health by cleaning up debugging artifacts from production logs, which aids readability and maintainability.
✅ **Verification:** Verified by running `pnpm run lint` and `pnpm test` successfully (excluding pre-existing, unrelated lint warnings).
✨ **Result:** Cleaned up logging output for the API route without altering core logic.

---
*PR created automatically by Jules for task [9664424072207487214](https://jules.google.com/task/9664424072207487214) started by @Jadenw9013*