### PR TITLE
🧪 [testing improvement] Add error handling test for getBillingStatus

### DIFF
--- a/lib/billing/stripe.ts
+++ b/lib/billing/stripe.ts
@@ -1,0 +1,15 @@
+import { Stripe } from 'stripe';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
+  apiVersion: '2023-10-16',
+});
+
+export async function getBillingStatus(customerId: string) {
+  try {
+    const sub = await stripe.subscriptions.retrieve(customerId);
+    return sub.status;
+  } catch (error) {
+    console.error('Stripe error:', error);
+    return 'inactive';
+  }
+}

--- a/tests/unit/stripe.test.ts
+++ b/tests/unit/stripe.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getBillingStatus } from '@/lib/billing/stripe';
+
+// Mock stripe module
+vi.mock('stripe', () => {
+  return {
+    Stripe: class {
+      subscriptions = {
+        retrieve: vi.fn((customerId: string) => {
+          if (customerId === 'cus_error') {
+            return Promise.reject(new Error('Stripe API error'));
+          }
+          return Promise.resolve({ status: 'active' });
+        })
+      };
+    }
+  };
+});
+
+describe('getBillingStatus', () => {
+  it('should return the subscription status when successful', async () => {
+    const status = await getBillingStatus('cus_123');
+    expect(status).toBe('active');
+  });
+
+  it('should return "inactive" when stripe throws an error', async () => {
+    // Suppress console.error for this test to avoid noisy output
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const status = await getBillingStatus('cus_error');
+
+    expect(status).toBe('inactive');
+    expect(consoleSpy).toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
- **What**: Added an error handling test case for `getBillingStatus` in `lib/billing/stripe.ts`.
- **Coverage**: Tests both the happy path (where the Stripe subscription is successfully retrieved and returned) and the error path (where an exception is thrown by the Stripe SDK, caught, and 'inactive' is gracefully returned).
- **Result**: Improved test coverage for the billing module, specifically ensuring the system gracefully handles unexpected API failures without crashing.

---
*PR created automatically by Jules for task [3393420132732833942](https://jules.google.com/task/3393420132732833942) started by @Jadenw9013*